### PR TITLE
Don't use whitespace check and check for end tag

### DIFF
--- a/src/Stubble.Helpers/HelperTagParser.cs
+++ b/src/Stubble.Helpers/HelperTagParser.cs
@@ -19,6 +19,7 @@ namespace Stubble.Helpers
 
             var nameStart = index;
 
+            // Skip whitespace or until end tag
             while (!slice[index].IsWhitespace() && !slice.Match(processor.CurrentTags.EndTag, index - slice.Start))
             {
                 index++;
@@ -26,11 +27,17 @@ namespace Stubble.Helpers
 
             var name = slice.ToString(nameStart, index);
 
-            if (!slice[index].IsWhitespace())
+            // Skip whitespace or until end tag
+            while (slice[index].IsWhitespace() && !slice.Match(processor.CurrentTags.EndTag, index - slice.Start))
+            {
+                index++;
+            }
+
+            // If we're at an end tag then it's not a helper
+            if (slice.Match(processor.CurrentTags.EndTag, index - slice.Start))
             {
                 return false;
             }
-            index++;
 
             var argsStart = index;
             slice.Start = index;

--- a/test/Stubble.Helpers.Test/HelperTests.cs
+++ b/test/Stubble.Helpers.Test/HelperTests.cs
@@ -56,6 +56,30 @@ public class HelperTests
     }
 
     [Fact]
+    public void StubbleShouldContinueWorkingAsNormalWithWhitespace()
+    {
+        var culture = new CultureInfo("en-GB");
+        var helpers = new Helpers()
+            .Register<decimal>("FormatCurrency", (context, count) =>
+            {
+                return count.ToString("C", culture);
+            });
+
+        var builder = new StubbleBuilder()
+            .Configure(conf =>
+            {
+                conf.AddHelpers(helpers);
+            })
+            .Build();
+
+        var tmpl = @"{{  Count  }}: {{  FormatCurrency Count  }}, {{  Count2  }}: {{  FormatCurrency Count2  }}";
+
+        var res = builder.Render(tmpl, new { Count = 10m, Count2 = 100.26m });
+
+        Assert.Equal("10: £10.00, 100.26: £100.26", res);
+    }
+
+    [Fact]
     public void HelpersShouldBeAbleToUseContextLookup()
     {
         var helpers = new Helpers()


### PR DESCRIPTION
Our format for helpers is Id[Whitespace]Arg1 so we should check that
we're not at an end tag and so the next value is an argument rather than
the id is followed by a space which isn't accurate

Fixes #2 