### PR TITLE
Correct namespace and culture dependency in tests

### DIFF
--- a/test/Stubble.Helpers.Test/HelperTests.cs
+++ b/test/Stubble.Helpers.Test/HelperTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Linq;
+using McMaster.Extensions.Xunit;
 using Stubble.Core.Builders;
 using Xunit;
 
@@ -33,6 +34,7 @@ namespace Stubble.Helpers.Test
         }
 
         [Fact]
+        [UseCulture("en-GB")]
         public void StubbleShouldContinueWorkingAsNormal()
         {
             var culture = new CultureInfo("en-GB");
@@ -53,10 +55,11 @@ namespace Stubble.Helpers.Test
 
             var res = builder.Render(tmpl, new { Count = 10m, Count2 = 100.26m });
 
-            Assert.Equal($"10: £10.00, {100.26m}: £100.26", res);
+            Assert.Equal("10: £10.00, 100.26: £100.26", res);
         }
 
         [Fact]
+        [UseCulture("en-GB")]
         public void StubbleShouldContinueWorkingAsNormalWithWhitespace()
         {
             var culture = new CultureInfo("en-GB");
@@ -77,7 +80,7 @@ namespace Stubble.Helpers.Test
 
             var res = builder.Render(tmpl, new { Count = 10m, Count2 = 100.26m });
 
-            Assert.Equal($"10: £10.00, {100.26m}: £100.26", res);
+            Assert.Equal("10: £10.00, 100.26: £100.26", res);
         }
 
         [Fact]

--- a/test/Stubble.Helpers.Test/HelperTests.cs
+++ b/test/Stubble.Helpers.Test/HelperTests.cs
@@ -10,6 +10,7 @@ namespace Stubble.Helpers.Test
     public class HelperTests
     {
         [Fact]
+        [UseCulture("en-GB")]
         public void RegisteredHelpersShouldBeRun()
         {
             var culture = new CultureInfo("en-GB");

--- a/test/Stubble.Helpers.Test/HelperTests.cs
+++ b/test/Stubble.Helpers.Test/HelperTests.cs
@@ -2,111 +2,113 @@
 using System.Globalization;
 using System.Linq;
 using Stubble.Core.Builders;
-using Stubble.Helpers;
 using Xunit;
 
-public class HelperTests
+namespace Stubble.Helpers.Test
 {
-    [Fact]
-    public void RegisteredHelpersShouldBeRun()
+    public class HelperTests
     {
-        var culture = new CultureInfo("en-GB");
-        var helpers = new Helpers()
-            .Register<decimal>("FormatCurrency", (context, count) =>
-            {
-                return count.ToString("C", culture);
-            });
+        [Fact]
+        public void RegisteredHelpersShouldBeRun()
+        {
+            var culture = new CultureInfo("en-GB");
+            var helpers = new Helpers()
+                .Register<decimal>("FormatCurrency", (context, count) =>
+                {
+                    return count.ToString("C", culture);
+                });
 
-        var builder = new StubbleBuilder()
-            .Configure(conf =>
-            {
-                conf.AddHelpers(helpers);
-            })
-            .Build();
+            var builder = new StubbleBuilder()
+                .Configure(conf =>
+                {
+                    conf.AddHelpers(helpers);
+                })
+                .Build();
 
-        var tmpl = @"{{FormatCurrency Count}}, {{FormatCurrency Count2}}";
+            var tmpl = @"{{FormatCurrency Count}}, {{FormatCurrency Count2}}";
 
-        var res = builder.Render(tmpl, new { Count = 10m, Count2 = 100.26m });
+            var res = builder.Render(tmpl, new { Count = 10m, Count2 = 100.26m });
 
-        Assert.Equal("£10.00, £100.26", res);
-    }
+            Assert.Equal("£10.00, £100.26", res);
+        }
 
-    [Fact]
-    public void StubbleShouldContinueWorkingAsNormal()
-    {
-        var culture = new CultureInfo("en-GB");
-        var helpers = new Helpers()
-            .Register<decimal>("FormatCurrency", (context, count) =>
-            {
-                return count.ToString("C", culture);
-            });
+        [Fact]
+        public void StubbleShouldContinueWorkingAsNormal()
+        {
+            var culture = new CultureInfo("en-GB");
+            var helpers = new Helpers()
+                .Register<decimal>("FormatCurrency", (context, count) =>
+                {
+                    return count.ToString("C", culture);
+                });
 
-        var builder = new StubbleBuilder()
-            .Configure(conf =>
-            {
-                conf.AddHelpers(helpers);
-            })
-            .Build();
+            var builder = new StubbleBuilder()
+                .Configure(conf =>
+                {
+                    conf.AddHelpers(helpers);
+                })
+                .Build();
 
-        var tmpl = @"{{Count}}: {{FormatCurrency Count}}, {{Count2}}: {{FormatCurrency Count2}}";
+            var tmpl = @"{{Count}}: {{FormatCurrency Count}}, {{Count2}}: {{FormatCurrency Count2}}";
 
-        var res = builder.Render(tmpl, new { Count = 10m, Count2 = 100.26m });
+            var res = builder.Render(tmpl, new { Count = 10m, Count2 = 100.26m });
 
-        Assert.Equal("10: £10.00, 100.26: £100.26", res);
-    }
+            Assert.Equal($"10: £10.00, {100.26m}: £100.26", res);
+        }
 
-    [Fact]
-    public void StubbleShouldContinueWorkingAsNormalWithWhitespace()
-    {
-        var culture = new CultureInfo("en-GB");
-        var helpers = new Helpers()
-            .Register<decimal>("FormatCurrency", (context, count) =>
-            {
-                return count.ToString("C", culture);
-            });
+        [Fact]
+        public void StubbleShouldContinueWorkingAsNormalWithWhitespace()
+        {
+            var culture = new CultureInfo("en-GB");
+            var helpers = new Helpers()
+                .Register<decimal>("FormatCurrency", (context, count) =>
+                {
+                    return count.ToString("C", culture);
+                });
 
-        var builder = new StubbleBuilder()
-            .Configure(conf =>
-            {
-                conf.AddHelpers(helpers);
-            })
-            .Build();
+            var builder = new StubbleBuilder()
+                .Configure(conf =>
+                {
+                    conf.AddHelpers(helpers);
+                })
+                .Build();
 
-        var tmpl = @"{{  Count  }}: {{  FormatCurrency Count  }}, {{  Count2  }}: {{  FormatCurrency Count2  }}";
+            var tmpl = @"{{  Count  }}: {{  FormatCurrency Count  }}, {{  Count2  }}: {{  FormatCurrency Count2  }}";
 
-        var res = builder.Render(tmpl, new { Count = 10m, Count2 = 100.26m });
+            var res = builder.Render(tmpl, new { Count = 10m, Count2 = 100.26m });
 
-        Assert.Equal("10: £10.00, 100.26: £100.26", res);
-    }
+            Assert.Equal($"10: £10.00, {100.26m}: £100.26", res);
+        }
 
-    [Fact]
-    public void HelpersShouldBeAbleToUseContextLookup()
-    {
-        var helpers = new Helpers()
-            .Register<int>("PrintWithComma", (context, count) =>
-            {
-                var arr = context.Lookup<int[]>("List");
-                var index = Array.IndexOf(arr, count);
-                var comma = index != arr.Length - 1
-                    ? ", "
-                    : "";
+        [Fact]
+        public void HelpersShouldBeAbleToUseContextLookup()
+        {
+            var helpers = new Helpers()
+                .Register<int>("PrintWithComma", (context, count) =>
+                {
+                    var arr = context.Lookup<int[]>("List");
+                    var index = Array.IndexOf(arr, count);
+                    var comma = index != arr.Length - 1
+                        ? ", "
+                        : "";
 
-                return $"{count}{comma}";
-            });
+                    return $"{count}{comma}";
+                });
 
-        var builder = new StubbleBuilder()
-            .Configure(conf =>
-            {
-                conf.AddHelpers(helpers);
-            })
-            .Build();
+            var builder = new StubbleBuilder()
+                .Configure(conf =>
+                {
+                    conf.AddHelpers(helpers);
+                })
+                .Build();
 
-        var tmpl = @"{{#List}}{{PrintWithComma .}}{{/List}}";
+            var tmpl = @"{{#List}}{{PrintWithComma .}}{{/List}}";
 
-        var list = Enumerable.Range(1, 10).ToArray();
+            var list = Enumerable.Range(1, 10).ToArray();
 
-        var res = builder.Render(tmpl, new { List = list });
+            var res = builder.Render(tmpl, new { List = list });
 
-        Assert.Equal(string.Join(", ", list), res);
+            Assert.Equal(string.Join(", ", list), res);
+        }
     }
 }

--- a/test/Stubble.Helpers.Test/RendererTest.cs
+++ b/test/Stubble.Helpers.Test/RendererTest.cs
@@ -1,235 +1,246 @@
-﻿
-using System;
+﻿using System;
 using System.Collections.Immutable;
 using System.IO;
 using Stubble.Core.Contexts;
 using Stubble.Core.Renderers.StringRenderer;
 using Stubble.Core.Settings;
-using Stubble.Helpers;
 using Xunit;
 
-public class RendererTests 
+namespace Stubble.Helpers.Test
 {
-    [Fact]
-    public void ItShouldRenderNothingWhenHelperDoesntExist()
+    public class RendererTests
     {
-        var writer = new StringWriter();
-        var settings = new RendererSettingsBuilder().BuildSettings();
-        var renderSettings = new RenderSettings();
-        var stringRenderer = new StringRender(writer, settings.RendererPipeline);
-
-        var helpers = ImmutableDictionary.Create<string, HelperRef>();
-
-        var tagRenderer = new HelperTagRenderer(helpers);
-
-        var token = new HelperToken {
-            Name = "MyHelper",
-            Args = Array.Empty<string>()
-        };
-
-        var context = new Context(new { Count = 10 }, settings, renderSettings);
-
-        tagRenderer.Write(stringRenderer, token, context);
-
-        var res = writer.ToString();
-
-        Assert.Equal("", res);
-    }
-
-    [Fact]
-    public void ItShouldCallHelperWhenExists()
-    {
-        var writer = new StringWriter();
-        var settings = new RendererSettingsBuilder().BuildSettings();
-        var renderSettings = new RenderSettings();
-        var stringRenderer = new StringRender(writer, settings.RendererPipeline);
-
-        var helpers = ImmutableDictionary.CreateBuilder<string, HelperRef>();
-
-        var helper = new Func<HelperContext, int, string>((helperContext, count) => {
-            return $"<{count}>";
-        });
-
-        helpers.Add("MyHelper", new HelperRef(helper));
-
-        var tagRenderer = new HelperTagRenderer(helpers.ToImmutable());
-
-        var token = new HelperToken {
-            Name = "MyHelper",
-            Args = new[] { "Count" }
-        };
-
-        var context = new Context(new { Count = 10 }, settings, renderSettings);
-
-        tagRenderer.Write(stringRenderer, token, context);
-
-        var res = writer.ToString();
-
-        Assert.Equal("<10>", res);
-    }
-
-    [Fact]
-    public void ItShouldCallHelperWhenExistsWithArgumentFromParent()
-    {
-        var writer = new StringWriter();
-        var settings = new RendererSettingsBuilder().BuildSettings();
-        var renderSettings = new RenderSettings();
-        var stringRenderer = new StringRender(writer, settings.RendererPipeline);
-
-        var helpers = ImmutableDictionary.CreateBuilder<string, HelperRef>();
-
-        var helper = new Func<HelperContext, int, int, string>((helperContext, count, count2) => {
-            return $"<{count}-{count2}>";
-        });
-
-        helpers.Add("MyHelper", new HelperRef(helper));
-
-        var tagRenderer = new HelperTagRenderer(helpers.ToImmutable());
-
-        var token = new HelperToken {
-            Name = "MyHelper",
-            Args = new[] { "Count", "Count2" }
-        };
-
-        var context = new Context(new { Count = 10 }, settings, renderSettings)
-            .Push(new { Count2 = 20 });
-
-        tagRenderer.Write(stringRenderer, token, context);
-
-        var res = writer.ToString();
-
-        Assert.Equal("<10-20>", res);
-    }
-
-    [Fact]
-    public void ItShouldCallHelperWhenExistsWithArgumentOverrideFromParent()
-    {
-        var writer = new StringWriter();
-        var settings = new RendererSettingsBuilder().BuildSettings();
-        var renderSettings = new RenderSettings();
-        var stringRenderer = new StringRender(writer, settings.RendererPipeline);
-
-        var helpers = ImmutableDictionary.CreateBuilder<string, HelperRef>();
-
-        var helper = new Func<HelperContext, int, int, string>((helperContext, count, count2) => {
-            return $"<{count}-{count2}>";
-        });
-
-        helpers.Add("MyHelper", new HelperRef(helper));
-
-        var tagRenderer = new HelperTagRenderer(helpers.ToImmutable());
-
-        var token = new HelperToken {
-            Name = "MyHelper",
-            Args = new[] { "Count", "Count2" }
-        };
-
-        var context = new Context(new { Count = 10 }, settings, renderSettings)
-            .Push(new { Count = 20, Count2 = 20 });
-
-        tagRenderer.Write(stringRenderer, token, context);
-
-        var res = writer.ToString();
-
-        Assert.Equal("<20-20>", res);
-    }
-
-    [Fact]
-    public void ItShouldRenderNothingWhenValueDoesntExist()
-    {
-        var writer = new StringWriter();
-        var settings = new RendererSettingsBuilder().BuildSettings();
-        var renderSettings = new RenderSettings();
-        var stringRenderer = new StringRender(writer, settings.RendererPipeline);
-
-        var helpers = ImmutableDictionary.CreateBuilder<string, HelperRef>();
-
-        var helper = new Func<HelperContext, int, string>((helperContext, count) => {
-            return $"<{count}>";
-        });
-
-        helpers.Add("MyHelper", new HelperRef(helper));
-
-        var tagRenderer = new HelperTagRenderer(helpers.ToImmutable());
-
-        var token = new HelperToken
+        [Fact]
+        public void ItShouldRenderNothingWhenHelperDoesntExist()
         {
-            Name = "MyHelper",
-            Args = new[] { "Count1" }
-        };
+            var writer = new StringWriter();
+            var settings = new RendererSettingsBuilder().BuildSettings();
+            var renderSettings = new RenderSettings();
+            var stringRenderer = new StringRender(writer, settings.RendererPipeline);
 
-        var context = new Context(new { Count = 10 }, settings, renderSettings);
+            var helpers = ImmutableDictionary.Create<string, HelperRef>();
 
-        tagRenderer.Write(stringRenderer, token, context);
+            var tagRenderer = new HelperTagRenderer(helpers);
 
-        var res = writer.ToString();
+            var token = new HelperToken
+            {
+                Name = "MyHelper",
+                Args = Array.Empty<string>()
+            };
 
-        Assert.Equal("", res);
-    }
+            var context = new Context(new { Count = 10 }, settings, renderSettings);
 
-    [Fact]
-    public void ItShouldRenderNothingWhenTypesDoNotMatch()
-    {
-        var writer = new StringWriter();
-        var settings = new RendererSettingsBuilder().BuildSettings();
-        var renderSettings = new RenderSettings();
-        var stringRenderer = new StringRender(writer, settings.RendererPipeline);
+            tagRenderer.Write(stringRenderer, token, context);
 
-        var helpers = ImmutableDictionary.CreateBuilder<string, HelperRef>();
+            var res = writer.ToString();
 
-        var helper = new Func<HelperContext, int, string>((helperContext, count) => {
-            return $"<{count}>";
-        });
+            Assert.Equal("", res);
+        }
 
-        helpers.Add("MyHelper", new HelperRef(helper));
-
-        var tagRenderer = new HelperTagRenderer(helpers.ToImmutable());
-
-        var token = new HelperToken
+        [Fact]
+        public void ItShouldCallHelperWhenExists()
         {
-            Name = "MyHelper",
-            Args = new[] { "Count" }
-        };
+            var writer = new StringWriter();
+            var settings = new RendererSettingsBuilder().BuildSettings();
+            var renderSettings = new RenderSettings();
+            var stringRenderer = new StringRender(writer, settings.RendererPipeline);
 
-        var context = new Context(new { Count = "10" }, settings, renderSettings);
+            var helpers = ImmutableDictionary.CreateBuilder<string, HelperRef>();
 
-        tagRenderer.Write(stringRenderer, token, context);
+            var helper = new Func<HelperContext, int, string>((helperContext, count) =>
+            {
+                return $"<{count}>";
+            });
 
-        var res = writer.ToString();
+            helpers.Add("MyHelper", new HelperRef(helper));
 
-        Assert.Equal("", res);
-    }
+            var tagRenderer = new HelperTagRenderer(helpers.ToImmutable());
 
-    [Fact]
-    public void ItShouldRenderAllowHelpersWithNoArguments()
-    {
-        var writer = new StringWriter();
-        var settings = new RendererSettingsBuilder().BuildSettings();
-        var renderSettings = new RenderSettings();
-        var stringRenderer = new StringRender(writer, settings.RendererPipeline);
+            var token = new HelperToken
+            {
+                Name = "MyHelper",
+                Args = new[] { "Count" }
+            };
 
-        var helpers = ImmutableDictionary.CreateBuilder<string, HelperRef>();
+            var context = new Context(new { Count = 10 }, settings, renderSettings);
 
-        var helper = new Func<HelperContext, string>((helperContext) => {
-            return $"<{helperContext.Lookup<int>("Count")}>";
-        });
+            tagRenderer.Write(stringRenderer, token, context);
 
-        helpers.Add("MyHelper", new HelperRef(helper));
+            var res = writer.ToString();
 
-        var tagRenderer = new HelperTagRenderer(helpers.ToImmutable());
+            Assert.Equal("<10>", res);
+        }
 
-        var token = new HelperToken
+        [Fact]
+        public void ItShouldCallHelperWhenExistsWithArgumentFromParent()
         {
-            Name = "MyHelper",
-            Args = Array.Empty<string>()
-        };
+            var writer = new StringWriter();
+            var settings = new RendererSettingsBuilder().BuildSettings();
+            var renderSettings = new RenderSettings();
+            var stringRenderer = new StringRender(writer, settings.RendererPipeline);
 
-        var context = new Context(new { Count = 10 }, settings, renderSettings);
+            var helpers = ImmutableDictionary.CreateBuilder<string, HelperRef>();
 
-        tagRenderer.Write(stringRenderer, token, context);
+            var helper = new Func<HelperContext, int, int, string>((helperContext, count, count2) =>
+            {
+                return $"<{count}-{count2}>";
+            });
 
-        var res = writer.ToString();
+            helpers.Add("MyHelper", new HelperRef(helper));
 
-        Assert.Equal("<10>", res);
+            var tagRenderer = new HelperTagRenderer(helpers.ToImmutable());
+
+            var token = new HelperToken
+            {
+                Name = "MyHelper",
+                Args = new[] { "Count", "Count2" }
+            };
+
+            var context = new Context(new { Count = 10 }, settings, renderSettings)
+                .Push(new { Count2 = 20 });
+
+            tagRenderer.Write(stringRenderer, token, context);
+
+            var res = writer.ToString();
+
+            Assert.Equal("<10-20>", res);
+        }
+
+        [Fact]
+        public void ItShouldCallHelperWhenExistsWithArgumentOverrideFromParent()
+        {
+            var writer = new StringWriter();
+            var settings = new RendererSettingsBuilder().BuildSettings();
+            var renderSettings = new RenderSettings();
+            var stringRenderer = new StringRender(writer, settings.RendererPipeline);
+
+            var helpers = ImmutableDictionary.CreateBuilder<string, HelperRef>();
+
+            var helper = new Func<HelperContext, int, int, string>((helperContext, count, count2) =>
+            {
+                return $"<{count}-{count2}>";
+            });
+
+            helpers.Add("MyHelper", new HelperRef(helper));
+
+            var tagRenderer = new HelperTagRenderer(helpers.ToImmutable());
+
+            var token = new HelperToken
+            {
+                Name = "MyHelper",
+                Args = new[] { "Count", "Count2" }
+            };
+
+            var context = new Context(new { Count = 10 }, settings, renderSettings)
+                .Push(new { Count = 20, Count2 = 20 });
+
+            tagRenderer.Write(stringRenderer, token, context);
+
+            var res = writer.ToString();
+
+            Assert.Equal("<20-20>", res);
+        }
+
+        [Fact]
+        public void ItShouldRenderNothingWhenValueDoesntExist()
+        {
+            var writer = new StringWriter();
+            var settings = new RendererSettingsBuilder().BuildSettings();
+            var renderSettings = new RenderSettings();
+            var stringRenderer = new StringRender(writer, settings.RendererPipeline);
+
+            var helpers = ImmutableDictionary.CreateBuilder<string, HelperRef>();
+
+            var helper = new Func<HelperContext, int, string>((helperContext, count) =>
+            {
+                return $"<{count}>";
+            });
+
+            helpers.Add("MyHelper", new HelperRef(helper));
+
+            var tagRenderer = new HelperTagRenderer(helpers.ToImmutable());
+
+            var token = new HelperToken
+            {
+                Name = "MyHelper",
+                Args = new[] { "Count1" }
+            };
+
+            var context = new Context(new { Count = 10 }, settings, renderSettings);
+
+            tagRenderer.Write(stringRenderer, token, context);
+
+            var res = writer.ToString();
+
+            Assert.Equal("", res);
+        }
+
+        [Fact]
+        public void ItShouldRenderNothingWhenTypesDoNotMatch()
+        {
+            var writer = new StringWriter();
+            var settings = new RendererSettingsBuilder().BuildSettings();
+            var renderSettings = new RenderSettings();
+            var stringRenderer = new StringRender(writer, settings.RendererPipeline);
+
+            var helpers = ImmutableDictionary.CreateBuilder<string, HelperRef>();
+
+            var helper = new Func<HelperContext, int, string>((helperContext, count) =>
+            {
+                return $"<{count}>";
+            });
+
+            helpers.Add("MyHelper", new HelperRef(helper));
+
+            var tagRenderer = new HelperTagRenderer(helpers.ToImmutable());
+
+            var token = new HelperToken
+            {
+                Name = "MyHelper",
+                Args = new[] { "Count" }
+            };
+
+            var context = new Context(new { Count = "10" }, settings, renderSettings);
+
+            tagRenderer.Write(stringRenderer, token, context);
+
+            var res = writer.ToString();
+
+            Assert.Equal("", res);
+        }
+
+        [Fact]
+        public void ItShouldRenderAllowHelpersWithNoArguments()
+        {
+            var writer = new StringWriter();
+            var settings = new RendererSettingsBuilder().BuildSettings();
+            var renderSettings = new RenderSettings();
+            var stringRenderer = new StringRender(writer, settings.RendererPipeline);
+
+            var helpers = ImmutableDictionary.CreateBuilder<string, HelperRef>();
+
+            var helper = new Func<HelperContext, string>((helperContext) =>
+            {
+                return $"<{helperContext.Lookup<int>("Count")}>";
+            });
+
+            helpers.Add("MyHelper", new HelperRef(helper));
+
+            var tagRenderer = new HelperTagRenderer(helpers.ToImmutable());
+
+            var token = new HelperToken
+            {
+                Name = "MyHelper",
+                Args = Array.Empty<string>()
+            };
+
+            var context = new Context(new { Count = 10 }, settings, renderSettings);
+
+            tagRenderer.Write(stringRenderer, token, context);
+
+            var res = writer.ToString();
+
+            Assert.Equal("<10>", res);
+        }
     }
 }

--- a/test/Stubble.Helpers.Test/Stubble.Helpers.Test.csproj
+++ b/test/Stubble.Helpers.Test/Stubble.Helpers.Test.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Stubble.Core" Version="1.3.4" />
+    <PackageReference Include="McMaster.Extensions.Xunit" Version="0.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
* Make the namespace for all test the same to make them easier to find in test explorer.
* When running test on non-English computer test was failing because the formatting expected `.` (dot) as decimal separator. 