### PR TITLE
Allow static inparameters into helper functions

### DIFF
--- a/src/Stubble.Helpers/HelperTagRenderer.cs
+++ b/src/Stubble.Helpers/HelperTagRenderer.cs
@@ -30,14 +30,13 @@ namespace Stubble.Helpers
 
                     for (var i = 0; i < args.Length; i++)
                     {
-                        var value = args[i];
-                        if (value.Length > 0 && ((value[0] == '"' && value[value.Length - 1] == '"') || value[0] == '\'' && value[value.Length - 1] == '\''))
+                        if (args[i].Length > 0 && ((args[i][0] == '"' && args[i][args[i].Length - 1] == '"') || args[i][0] == '\'' && args[i][args[i].Length - 1] == '\''))
                         {
-                            arr[i + 1] = Convert.ChangeType(value.Substring(1, value.Length - 2), argumentTypes[i + 1]);
+                            arr[i + 1] = Convert.ChangeType(args[i].Substring(1, args[i].Length - 2), argumentTypes[i + 1]);
                         }
                         else
                         {
-                            var lookup = context.Lookup(value);
+                            var lookup = context.Lookup(args[i]);
                             if (lookup is null)
                             {
                                 return;

--- a/src/Stubble.Helpers/HelperTagRenderer.cs
+++ b/src/Stubble.Helpers/HelperTagRenderer.cs
@@ -30,7 +30,7 @@ namespace Stubble.Helpers
 
                     for (var i = 0; i < args.Length; i++)
                     {
-                        if (args[i].Length > 0 && ((args[i][0] == '"' && args[i][args[i].Length - 1] == '"') || args[i][0] == '\'' && args[i][args[i].Length - 1] == '\''))
+                        if (args[i].Length > 0 && args[i][0] == '"' && args[i][args[i].Length - 1] == '"')
                         {
                             arr[i + 1] = Convert.ChangeType(args[i].Substring(1, args[i].Length - 2), argumentTypes[i + 1]);
                         }

--- a/src/Stubble.Helpers/HelperTagRenderer.cs
+++ b/src/Stubble.Helpers/HelperTagRenderer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using System;
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Stubble.Core.Contexts;
 using Stubble.Core.Renderers.StringRenderer;
@@ -29,19 +30,27 @@ namespace Stubble.Helpers
 
                     for (var i = 0; i < args.Length; i++)
                     {
-                        var lookup = context.Lookup(args[i]);
-                        if (lookup is null)
+                        var value = args[i];
+                        if (value.Length > 0 && ((value[0] == '"' && value[value.Length - 1] == '"') || value[0] == '\'' && value[value.Length - 1] == '\''))
                         {
-                            return;
-                        }
-
-                        if (argumentTypes[i + 1] == lookup.GetType())
-                        {
-                            arr[i + 1] = lookup;
+                            arr[i + 1] = Convert.ChangeType(value.Substring(1, value.Length - 2), argumentTypes[i + 1]);
                         }
                         else
                         {
-                            return;
+                            var lookup = context.Lookup(value);
+                            if (lookup is null)
+                            {
+                                return;
+                            }
+
+                            if (argumentTypes[i + 1] == lookup.GetType())
+                            {
+                                arr[i + 1] = lookup;
+                            }
+                            else
+                            {
+                                return;
+                            }
                         }
                     }
 

--- a/test/Stubble.Helpers.Test/ParserTest.cs
+++ b/test/Stubble.Helpers.Test/ParserTest.cs
@@ -41,6 +41,22 @@ namespace Stubble.Helpers.Test
             Assert.Equal("MyArgument", helperToken.Args[0]);
         }
 
+        [Theory]
+        [InlineData("{{MyHelper \"MyArgument\"}}", "\"MyArgument\"")]
+        [InlineData("{{MyHelper \"My Argument\"}}", "\"My Argument\"")]
+        public void ItParsesHelpersWithStaticArgument(string data, string expectedArgument)
+        {
+            var parser = new InstanceMustacheParser();
+            var pipeline = BuildHelperPipeline();
+
+            var tokens = parser.Parse(data, pipeline: pipeline);
+
+            Assert.Single(tokens.Children);
+            var helperToken = Assert.IsType<HelperToken>(tokens.Children[0]);
+            Assert.Equal("MyHelper", helperToken.Name.ToString());
+            Assert.Equal(expectedArgument, helperToken.Args[0]);
+        }
+
         [Fact]
         public void ItParsesHelpersWithMultipleArguments()
         {

--- a/test/Stubble.Helpers.Test/RendererTest.cs
+++ b/test/Stubble.Helpers.Test/RendererTest.cs
@@ -170,6 +170,8 @@ public class RendererTests
     [Theory]
     [InlineData("'Count'", '\'')]
     [InlineData("\"Count\"", '"')]
+    [InlineData("\"Word with spaces\"", '"')]
+    [InlineData("\"Word with spaces and quote \\\" inside\"", '"')]
     public void ItShouldCallHelperWhenExistsStaticVariable(string inputData, char trimCharacter)
     {
         var writer = new StringWriter();

--- a/test/Stubble.Helpers.Test/RendererTest.cs
+++ b/test/Stubble.Helpers.Test/RendererTest.cs
@@ -168,7 +168,6 @@ public class RendererTests
     }
 
     [Theory]
-    [InlineData("'Count'", '\'')]
     [InlineData("\"Count\"", '"')]
     [InlineData("\"Word with spaces\"", '"')]
     [InlineData("\"Word with spaces and quote \\\" inside\"", '"')]
@@ -205,15 +204,14 @@ public class RendererTests
         Assert.Equal($"<{inputData.Trim(trimCharacter)}>", res);
     }
 
-    [Theory]
-    [InlineData("'Count'", '\'')]
-    [InlineData("\"Count\"", '"')]
-    public void ItShouldCallHelperWhenExistsStaticAndDynamicVariable(string inputData, char trimCharacter)
-    {
-        var writer = new StringWriter();
-        var settings = new RendererSettingsBuilder().BuildSettings();
-        var renderSettings = new RenderSettings();
-        var stringRenderer = new StringRender(writer, settings.RendererPipeline);
+        [Theory]
+        [InlineData("\"Count\"", '"')]
+        public void ItShouldCallHelperWhenExistsStaticAndDynamicVariable(string inputData, char trimCharacter)
+        {
+            var writer = new StringWriter();
+            var settings = new RendererSettingsBuilder().BuildSettings();
+            var renderSettings = new RenderSettings();
+            var stringRenderer = new StringRender(writer, settings.RendererPipeline);
 
         var helpers = ImmutableDictionary.CreateBuilder<string, HelperRef>();
 


### PR DESCRIPTION
When the input parameters to the functions is parsed it always was expected to be token replacement, sometimes a static string is needed. 

In my use-case I want to input the count of characters a text should be indented, it can be solved without static placeholders if I add the count as a replacement but it should be easier to allow fixed input strings.