### PR TITLE
Render tag if the type can be converted

### DIFF
--- a/src/Stubble.Helpers/HelperTagRenderer.cs
+++ b/src/Stubble.Helpers/HelperTagRenderer.cs
@@ -31,27 +31,14 @@ namespace Stubble.Helpers
                     for (var i = 0; i < args.Length; i++)
                     {
                         var lookup = context.Lookup(args[i]);
+                        lookup = TryConvertTypeIfRequired(lookup, argumentTypes[i + 1]);
 
                         if (lookup is null)
                         {
                             return;
                         }
 
-                        if (argumentTypes[i + 1].IsAssignableFrom(lookup.GetType()))
-                        {
-                            arr[i + 1] = lookup;
-                            continue;
-                        }
-
-                        try
-                        {
-                            var convertedType = Convert.ChangeType(lookup, argumentTypes[i + 1]);
-                            arr[i + 1] = convertedType;
-                        }
-                        catch
-                        {
-                            return;
-                        }
+                        arr[i + 1] = lookup;
                     }
 
                     var result = helper.Delegate.Method.Invoke(helper.Delegate.Target, arr);
@@ -67,6 +54,36 @@ namespace Stubble.Helpers
         {
             Write(renderer, obj, context);
             return Task.CompletedTask;
+        }
+
+        public static object TryConvertTypeIfRequired(object lookup, Type type)
+        {
+            if (lookup is null)
+            {
+                return null;
+            }
+
+            var lookupType = lookup.GetType();
+
+            if (lookupType == type)
+            {
+                return lookup;
+            }
+
+            if (type.IsAssignableFrom(lookupType))
+            {
+                return lookup;
+            }
+
+            try
+            {
+                return Convert.ChangeType(lookup, type);
+            }
+            catch
+            {
+            }
+
+            return null;
         }
     }
 }

--- a/src/Stubble.Helpers/HelperTagRenderer.cs
+++ b/src/Stubble.Helpers/HelperTagRenderer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using System;
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Stubble.Core.Contexts;
 using Stubble.Core.Renderers.StringRenderer;
@@ -36,11 +37,18 @@ namespace Stubble.Helpers
                             return;
                         }
 
-                        if (argumentTypes[i + 1] == lookup.GetType())
+                        if (argumentTypes[i + 1].IsAssignableFrom(lookup.GetType()))
                         {
                             arr[i + 1] = lookup;
+                            continue;
                         }
-                        else
+
+                        try
+                        {
+                            var convertedType = Convert.ChangeType(lookup, argumentTypes[i + 1]);
+                            arr[i + 1] = convertedType;
+                        }
+                        catch
                         {
                             return;
                         }


### PR DESCRIPTION
When using base classes (or interfaces) for the helper method argument types the equal comparison of type is failing. even that the type will work in run time

Instead of using the equal operator we can check with `IsAssignableFrom` and if that is failing we can also try to convert the input type to the expected output type (example: converting a string with a number to an int).