### PR TITLE
Check parent context for value

### DIFF
--- a/src/Stubble.Helpers/HelperTagRenderer.cs
+++ b/src/Stubble.Helpers/HelperTagRenderer.cs
@@ -30,6 +30,12 @@ namespace Stubble.Helpers
                     for (var i = 0; i < args.Length; i++)
                     {
                         var lookup = context.Lookup(args[i]);
+                        var currentContext = context;
+                        while (lookup is null && (currentContext = currentContext.ParentContext) != null)
+                        {
+                            lookup = currentContext.Lookup(args[i]);
+                        }
+
                         if (lookup is null)
                         {
                             return;

--- a/test/Stubble.Helpers.Test/RendererTest.cs
+++ b/test/Stubble.Helpers.Test/RendererTest.cs
@@ -69,6 +69,72 @@ public class RendererTests
     }
 
     [Fact]
+    public void ItShouldCallHelperWhenExistsWithArgumentFromParent()
+    {
+        var writer = new StringWriter();
+        var settings = new RendererSettingsBuilder().BuildSettings();
+        var renderSettings = new RenderSettings();
+        var stringRenderer = new StringRender(writer, settings.RendererPipeline);
+
+        var helpers = ImmutableDictionary.CreateBuilder<string, HelperRef>();
+
+        var helper = new Func<HelperContext, int, int, string>((helperContext, count, count2) => {
+            return $"<{count}-{count2}>";
+        });
+
+        helpers.Add("MyHelper", new HelperRef(helper));
+
+        var tagRenderer = new HelperTagRenderer(helpers.ToImmutable());
+
+        var token = new HelperToken {
+            Name = "MyHelper",
+            Args = new[] { "Count", "Count2" }
+        };
+
+        var context = new Context(new { Count = 10 }, settings, renderSettings)
+            .Push(new { Count2 = 20 });
+
+        tagRenderer.Write(stringRenderer, token, context);
+
+        var res = writer.ToString();
+
+        Assert.Equal("<10-20>", res);
+    }
+
+    [Fact]
+    public void ItShouldCallHelperWhenExistsWithArgumentOverrideFromParent()
+    {
+        var writer = new StringWriter();
+        var settings = new RendererSettingsBuilder().BuildSettings();
+        var renderSettings = new RenderSettings();
+        var stringRenderer = new StringRender(writer, settings.RendererPipeline);
+
+        var helpers = ImmutableDictionary.CreateBuilder<string, HelperRef>();
+
+        var helper = new Func<HelperContext, int, int, string>((helperContext, count, count2) => {
+            return $"<{count}-{count2}>";
+        });
+
+        helpers.Add("MyHelper", new HelperRef(helper));
+
+        var tagRenderer = new HelperTagRenderer(helpers.ToImmutable());
+
+        var token = new HelperToken {
+            Name = "MyHelper",
+            Args = new[] { "Count", "Count2" }
+        };
+
+        var context = new Context(new { Count = 10 }, settings, renderSettings)
+            .Push(new { Count = 20, Count2 = 20 });
+
+        tagRenderer.Write(stringRenderer, token, context);
+
+        var res = writer.ToString();
+
+        Assert.Equal("<20-20>", res);
+    }
+
+    [Fact]
     public void ItShouldRenderNothingWhenValueDoesntExist()
     {
         var writer = new StringWriter();


### PR DESCRIPTION
When using a helper class inside a section-block and have a value that is specified in a parent context object, the value is not resolved correctly.