### PR TITLE
Fix build warnings

### DIFF
--- a/src/Stubble.Helpers/HelperContext.cs
+++ b/src/Stubble.Helpers/HelperContext.cs
@@ -7,11 +7,11 @@ namespace Stubble.Helpers
 {
     public class HelperContext
     {
-        private readonly Context context;
+        private readonly Context _context;
 
         public HelperContext(Context context)
         {
-            this.context = context;
+            _context = context;
         }
 
         /// <summary>
@@ -32,9 +32,9 @@ namespace Stubble.Helpers
         /// <exception cref="InvalidCastException">If the type <typeparamref name="T"/> does not match the found type</exception>
         /// <returns>The value if found or null if not</returns>
         public T Lookup<T>(string name)
-            => (T)context.Lookup(name);
+            => (T)_context.Lookup(name);
 
         public bool IsTruthyValue(object value)
-            => context.IsTruthyValue(value);
+            => _context.IsTruthyValue(value);
     }
 }

--- a/src/Stubble.Helpers/HelperExtensions.cs
+++ b/src/Stubble.Helpers/HelperExtensions.cs
@@ -10,6 +10,16 @@ namespace Stubble.Helpers
     {
         public static RendererSettingsBuilder AddHelpers(this RendererSettingsBuilder builder, Helpers helpers)
         {
+            if (builder is null)
+            {
+                throw new System.ArgumentNullException(nameof(builder));
+            }
+
+            if (helpers is null)
+            {
+                throw new System.ArgumentNullException(nameof(helpers));
+            }
+
             builder.ConfigureParserPipeline(pipelineBuilder => pipelineBuilder
                 .AddBefore<InterpolationTagParser>(new HelperTagParser()));
 

--- a/src/Stubble.Helpers/HelperRef.cs
+++ b/src/Stubble.Helpers/HelperRef.cs
@@ -8,7 +8,7 @@ namespace Stubble.Helpers
     {
         public HelperRef(Delegate @delegate)
         {
-            Delegate = @delegate;
+            Delegate = @delegate ?? throw new ArgumentNullException(nameof(@delegate));
 
             var @params = @delegate.Method.GetParameters();
             var builder = ImmutableArray.CreateBuilder<Type>(@params.Length);
@@ -43,6 +43,16 @@ namespace Stubble.Helpers
                 hashCode = hashCode * -1521134295 + EqualityComparer<Type>.Default.GetHashCode(type);
             }
             return hashCode;
+        }
+
+        public static bool operator ==(HelperRef left, HelperRef right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(HelperRef left, HelperRef right)
+        {
+            return !(left == right);
         }
     }
 }

--- a/src/Stubble.Helpers/HelperTagParser.cs
+++ b/src/Stubble.Helpers/HelperTagParser.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using Stubble.Core.Exceptions;
 using Stubble.Core.Imported;
@@ -12,6 +12,11 @@ namespace Stubble.Helpers
     {
         public override bool Match(Processor processor, ref StringSlice slice)
         {
+            if (processor is null)
+            {
+                throw new System.ArgumentNullException(nameof(processor));
+            }
+
             var tagStart = slice.Start - processor.CurrentTags.StartTag.Length;
             var index = slice.Start;
 
@@ -56,7 +61,7 @@ namespace Stubble.Helpers
 
             if (!slice.Match(processor.CurrentTags.EndTag))
             {
-                throw new StubbleException($"Unclosed Tag at {slice.Start.ToString()}");
+                throw new StubbleException($"Unclosed Tag at {slice.Start.ToString(CultureInfo.InvariantCulture)}");
             }
 
             var argsList = ParseArguments(new StringSlice(args.Text, args.Start, args.End));

--- a/src/Stubble.Helpers/HelperTagRenderer.cs
+++ b/src/Stubble.Helpers/HelperTagRenderer.cs
@@ -18,6 +18,21 @@ namespace Stubble.Helpers
 
         protected override void Write(StringRender renderer, HelperToken obj, Context context)
         {
+            if (renderer is null)
+            {
+                throw new ArgumentNullException(nameof(renderer));
+            }
+
+            if (obj is null)
+            {
+                throw new ArgumentNullException(nameof(obj));
+            }
+
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
             if (_helperCache.TryGetValue(obj.Name, out var helper))
             {
                 var helperContext = new HelperContext(context);
@@ -84,7 +99,9 @@ namespace Stubble.Helpers
             {
                 return Convert.ChangeType(value, type, CultureInfo.InvariantCulture);
             }
+#pragma warning disable CA1031 // Do not catch general exception types
             catch
+#pragma warning restore CA1031 // Do not catch general exception types
             {
             }
 

--- a/test/Stubble.Helpers.Test/RendererTest.cs
+++ b/test/Stubble.Helpers.Test/RendererTest.cs
@@ -256,8 +256,7 @@ namespace Stubble.Helpers.Test
 
             var helper = new Func<HelperContext, object, string>((helperContext, src) =>
             {
-                var dic = src as IDictionary<object, object>;
-                if (dic == null)
+                if (!(src is IDictionary<object, object> dic))
                 {
                     return string.Empty;
                 }


### PR DESCRIPTION
MSBuild shows some warning about wrong code style or missing null-checks. This PR will fix the code suggestions.

The only part that not is fixed is that the class `Helpers` is in namespace `Stubble.Helpers` this make a warning about that namespace and class not should be named the same as namespace.
> Helpers.cs(7,18,7,25): warning CA1724: The type name Helpers conflicts in whole or in part with the namespace name 'Stubble.Core.Helpers'. Change either name to eliminate the conflict.