### PR TITLE
Add possibility to link helpers with each other

### DIFF
--- a/src/Stubble.Helpers/HelperExtensions.cs
+++ b/src/Stubble.Helpers/HelperExtensions.cs
@@ -11,9 +11,11 @@ namespace Stubble.Helpers
         public static RendererSettingsBuilder AddHelpers(this RendererSettingsBuilder builder, Helpers helpers)
         {
             builder.ConfigureParserPipeline(pipelineBuilder => pipelineBuilder
-                .AddBefore<InterpolationTagParser>(new HelperTagParser()));
+                .AddBefore<InterpolationTagParser>(helpers.IsLinkedHelpersAllowed ? new LinkedHelperTagParser() : new HelperTagParser()));
 
-            builder.TokenRenderers.Add(new HelperTagRenderer(helpers.HelperMap));
+            var helperTagRender = new HelperTagRenderer(helpers.HelperMap);
+            builder.TokenRenderers.Add(helperTagRender);
+            builder.TokenRenderers.Add(new LinkedHelperRenderer(helperTagRender));
 
             return builder;
         }

--- a/src/Stubble.Helpers/HelperTagRenderer.cs
+++ b/src/Stubble.Helpers/HelperTagRenderer.cs
@@ -18,6 +18,21 @@ namespace Stubble.Helpers
 
         protected override void Write(StringRender renderer, HelperToken obj, Context context)
         {
+            var content = GetContent(obj, context);
+            if (!(content is null))
+            {
+                renderer.Write(content);
+            }
+        }
+
+        protected override Task WriteAsync(StringRender renderer, HelperToken obj, Context context)
+        {
+            Write(renderer, obj, context);
+            return Task.CompletedTask;
+        }
+
+        public string GetContent(HelperToken obj, Context context)
+        {
             if (_helperCache.TryGetValue(obj.Name, out var helper))
             {
                 var helperContext = new HelperContext(context);
@@ -39,25 +54,16 @@ namespace Stubble.Helpers
 
                         if (arg is null)
                         {
-                            return;
+                            return null;
                         }
 
                         arr[i + 1] = arg;
                     }
 
-                    var result = helper.Delegate.Method.Invoke(helper.Delegate.Target, arr);
-                    if (result is string str)
-                    {
-                        renderer.Write(str);
-                    }
+                    return helper.Delegate.Method.Invoke(helper.Delegate.Target, arr) as string;
                 }
             }
-        }
-
-        protected override Task WriteAsync(StringRender renderer, HelperToken obj, Context context)
-        {
-            Write(renderer, obj, context);
-            return Task.CompletedTask;
+            return null;
         }
 
         private static object TryConvertTypeIfRequired(object value, string arg, Type type)

--- a/src/Stubble.Helpers/HelperToken.cs
+++ b/src/Stubble.Helpers/HelperToken.cs
@@ -9,6 +9,11 @@ namespace Stubble.Helpers
 
         public ImmutableArray<HelperArgument> Args { get; set; }
 
+        public HelperToken Clone()
+        {
+            return (HelperToken)MemberwiseClone();
+        }
+
         public override bool Equals(HelperToken other) =>
             other is object
             && (other.TagStartPosition, other.TagEndPosition, other.ContentStartPosition, other.ContentEndPosition, other.IsClosed)

--- a/src/Stubble.Helpers/Helpers.cs
+++ b/src/Stubble.Helpers/Helpers.cs
@@ -11,6 +11,8 @@ namespace Stubble.Helpers
 
         public ImmutableDictionary<string, HelperRef> HelperMap => _helpers.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase);
 
+        public bool IsLinkedHelpersAllowed { get; private set; }
+
         public Helpers Register(string name, Func<HelperContext, string> func) => Register(name, (Delegate)func);
         public Helpers Register<T2>(string name, Func<HelperContext, T2, string> func) => Register(name, (Delegate)func);
         public Helpers Register<T2, T3>(string name, Func<HelperContext, T2, T3, string> func) => Register(name, (Delegate)func);
@@ -35,6 +37,12 @@ namespace Stubble.Helpers
             }
 
             _helpers[name.Trim()] = new HelperRef(@delegate);
+            return this;
+        }
+
+        public Helpers AllowLinkedHelpers(bool allow = true)
+        {
+            IsLinkedHelpersAllowed = allow;
             return this;
         }
     }

--- a/src/Stubble.Helpers/LinkedHelperRenderer.cs
+++ b/src/Stubble.Helpers/LinkedHelperRenderer.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Stubble.Core.Contexts;
+using Stubble.Core.Renderers.StringRenderer;
+
+namespace Stubble.Helpers
+{
+    public class LinkedHelperRenderer : StringObjectRenderer<LinkedHelperTokens>
+    {
+        private readonly HelperTagRenderer _helperTagRender;
+
+        public LinkedHelperRenderer(HelperTagRenderer helperTagRender)
+        {
+            _helperTagRender = helperTagRender;
+        }
+
+        protected override void Write(StringRender renderer, LinkedHelperTokens obj, Context context)
+        {
+            string result = null;
+            for (var i = 0; i < obj.Tokens.Count; i++)
+            {
+                var token = obj.Tokens[i];
+                if (i > 0)
+                {
+                    var args = ImmutableArray.CreateBuilder<HelperArgument>();
+                    args.Add(new HelperArgument(result, false));
+                    if (token.Args != null)
+                    {
+                        args.AddRange(token.Args);
+                    }
+                    token = token.Clone();
+                    token.Args = args.ToImmutable();
+                }
+                result = _helperTagRender.GetContent(token, context);
+            }
+
+            if (!(result is null))
+            {
+                renderer.Write(result);
+            }
+        }
+
+        protected override Task WriteAsync(StringRender renderer, LinkedHelperTokens obj, Context context)
+        {
+            Write(renderer, obj, context);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Stubble.Helpers/LinkedHelperTagParser.cs
+++ b/src/Stubble.Helpers/LinkedHelperTagParser.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Stubble.Core.Imported;
+using Stubble.Core.Parser;
+
+namespace Stubble.Helpers
+{
+    public class LinkedHelperTagParser : HelperTagParser
+    {
+        private const string _linkedTagSeparator = "|";
+
+        public override bool Match(Processor processor, ref StringSlice slice)
+        {
+            var tag = ParseHelperToken(processor, ref slice);
+            if (tag == null)
+            {
+                return false;
+            }
+
+            if (slice.Match(processor.CurrentTags.EndTag))
+            {
+                processor.CurrentToken = tag;
+            }
+            else
+            {
+                var tokens = new List<HelperToken> { tag };
+                while (slice.Match(_linkedTagSeparator))
+                {
+                    slice.NextChar();
+                    tag = ParseHelperToken(processor, ref slice, true);
+                    if (tag == null)
+                    {
+                        return false;
+                    }
+                    tokens.Add(tag);
+                }
+
+                if (!slice.Match(processor.CurrentTags.EndTag))
+                {
+                    return false;
+                }
+                processor.CurrentToken = new LinkedHelperTokens(tokens);
+            }
+
+            slice.Start += processor.CurrentTags.EndTag.Length;
+            processor.HasSeenNonSpaceOnLine = true;
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected override bool MatchEndTag(Processor processor, ref StringSlice slice, int offset = 0)
+            => slice.Match(processor.CurrentTags.EndTag, offset) || slice.Match(_linkedTagSeparator, offset);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected override int StartTagLength(Processor processor, ref StringSlice slice)
+            => slice.Match(processor.CurrentTags.StartTag) ? processor.CurrentTags.StartTag.Length : _linkedTagSeparator.Length;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected override int EndTagLength(Processor processor, ref StringSlice slice)
+            => slice.Match(processor.CurrentTags.EndTag) ? processor.CurrentTags.EndTag.Length : _linkedTagSeparator.Length;
+    }
+}

--- a/src/Stubble.Helpers/LinkedHelperTokens.cs
+++ b/src/Stubble.Helpers/LinkedHelperTokens.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using Stubble.Core.Tokens;
+
+namespace Stubble.Helpers
+{
+    public class LinkedHelperTokens : InlineToken<LinkedHelperTokens>, INonSpace
+    {
+        public LinkedHelperTokens(IList<HelperToken> tokens)
+        {
+            Tokens = tokens;
+        }
+
+        public IList<HelperToken> Tokens { get; }
+
+        public override bool Equals(LinkedHelperTokens other)
+        {
+            if (Tokens.Count != other.Tokens.Count)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < Tokens.Count; i++)
+            {
+                if (!Tokens[i].Equals(other.Tokens[i]))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public override bool Equals(object obj)
+        {
+            var other = obj as LinkedHelperTokens;
+            return other != null && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            var combinedHash = 5381;
+            foreach (var token in Tokens)
+            {
+                CombineHashCode(token.GetHashCode());
+            }
+            return combinedHash;
+
+            void CombineHashCode(int n) => combinedHash = ((combinedHash << 5) + combinedHash) ^ n;
+        }
+    }
+}

--- a/test/Stubble.Helpers.Test/HelperTests.cs
+++ b/test/Stubble.Helpers.Test/HelperTests.cs
@@ -84,6 +84,35 @@ namespace Stubble.Helpers.Test
             Assert.Equal("10: £10.00, 100.26: £100.26", res);
         }
 
+        [Theory]
+        [InlineData("{{FormatCurrency Count|Quote}}", "\"£10.00\"")]
+        [InlineData("{{FormatCurrency Count | Quote }}", "\"£10.00\"")]
+        [InlineData("{{FormatCurrency Count|Quote|Quote}}", "\"\"£10.00\"\"")]
+        [InlineData("{{FormatCurrency Count | Quote | Quote }}", "\"\"£10.00\"\"")]
+        public void RegisteredLinkedHelpersShouldBeRun(string tmpl, string expected)
+        {
+            var culture = new CultureInfo("en-GB");
+            var helpers = new Helpers()
+                .Register<decimal>("FormatCurrency", (context, count) =>
+                {
+                    return count.ToString("C", culture);
+                })
+                .Register<string>("Quote", (context, value)
+                    => string.Concat("\"", value, "\""))
+                .AllowLinkedHelpers();
+
+            var builder = new StubbleBuilder()
+                .Configure(conf =>
+                {
+                    conf.AddHelpers(helpers);
+                })
+                .Build();
+
+            var res = builder.Render(tmpl, new { Count = 10m });
+
+            Assert.Equal(expected, res);
+        }
+
         [Fact]
         public void HelpersShouldBeAbleToUseContextLookup()
         {

--- a/test/Stubble.Helpers.Test/RendererTest.cs
+++ b/test/Stubble.Helpers.Test/RendererTest.cs
@@ -316,5 +316,104 @@ namespace Stubble.Helpers.Test
 
             Assert.Equal("<10>", res);
         }
+
+        [Fact]
+        public void ItShouldRenderAllowLnkedHelpersWithNoArguments()
+        {
+            var writer = new StringWriter();
+            var settings = new RendererSettingsBuilder().BuildSettings();
+            var renderSettings = new RenderSettings();
+            var stringRenderer = new StringRender(writer, settings.RendererPipeline);
+
+            var helpers = ImmutableDictionary.CreateBuilder<string, HelperRef>();
+
+            var helper = new Func<HelperContext, int, string>((helperContext, count) =>
+            {
+                return $"<{count}>";
+            });
+
+            helpers.Add("MyHelper", new HelperRef(helper));
+
+            var pipedHelper = new Func<HelperContext, string, string>((helperContext, pipedValue) =>
+            {
+                return string.Concat("\"", pipedValue, "\"");
+            });
+
+            helpers.Add("PipedHelper", new HelperRef(pipedHelper));
+
+            var tagRenderer = new HelperTagRenderer(helpers.ToImmutable());
+            var linkedTagRender = new LinkedHelperRenderer(tagRenderer);
+
+            var token = new LinkedHelperTokens(new[]
+                {
+                    new HelperToken
+                    {
+                        Name = "MyHelper",
+                        Args = ImmutableArray.Create(new HelperArgument("Count"))
+                    },
+                    new HelperToken
+                    {
+                        Name = "PipedHelper",
+                    },
+                });
+
+            var context = new Context(new { Count = 10 }, settings, renderSettings);
+
+            linkedTagRender.Write(stringRenderer, token, context);
+
+            var res = writer.ToString();
+
+            Assert.Equal("\"<10>\"", res);
+        }
+
+        [Fact]
+        public void ItShouldRenderAllowLnkedHelpersWithArguments()
+        {
+            var writer = new StringWriter();
+            var settings = new RendererSettingsBuilder().BuildSettings();
+            var renderSettings = new RenderSettings();
+            var stringRenderer = new StringRender(writer, settings.RendererPipeline);
+
+            var helpers = ImmutableDictionary.CreateBuilder<string, HelperRef>();
+
+            var helper = new Func<HelperContext, int, string>((helperContext, count) =>
+            {
+                return $"<{count}>";
+            });
+
+            helpers.Add("MyHelper", new HelperRef(helper));
+
+            var pipedHelper = new Func<HelperContext, string, string, string>((helperContext, pipedValue, pipedArgument) =>
+            {
+                return string.Concat("\"", pipedValue, pipedArgument, "\"");
+            });
+
+            helpers.Add("PipedHelper", new HelperRef(pipedHelper));
+
+            var tagRenderer = new HelperTagRenderer(helpers.ToImmutable());
+            var linkedTagRender = new LinkedHelperRenderer(tagRenderer);
+
+            var token = new LinkedHelperTokens(new[]
+                {
+                    new HelperToken
+                    {
+                        Name = "MyHelper",
+                        Args =  ImmutableArray.Create(new HelperArgument("Count"))
+                    },
+                    new HelperToken
+                    {
+                        Name = "PipedHelper",
+                        Args =  ImmutableArray.Create(new HelperArgument("MyArgument", false))
+                    },
+                });
+
+            var context = new Context(new { Count = 10 }, settings, renderSettings);
+
+            linkedTagRender.Write(stringRenderer, token, context);
+
+            var res = writer.ToString();
+
+            Assert.Equal("\"<10>MyArgument\"", res);
+        }
     }
 }

--- a/test/Stubble.Helpers.Test/Stubble.Helpers.Test.csproj
+++ b/test/Stubble.Helpers.Test/Stubble.Helpers.Test.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Stubble.Core" Version="1.4.12" />
     <PackageReference Include="McMaster.Extensions.Xunit" Version="0.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">


### PR DESCRIPTION
In my project I need to be able to link different functions together to not need to build multiple similar functionality that only contains small differences. Not sure if you think this will fit into what you want to have in the helper library.

Example I have a method that returning a file-name this filename need to be base64 encoded and the base64-encoded result need to be rendered.

