### PR TITLE
Helpers without arguments aren't accepted

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ var builder = new StubbleBuilder()
 
 var res = builder.Render("List: {{PrintListWithComma}}", new { List = new[] { 1, 2, 3 } });
 
-Assert.Equal("1, 2, 3", res);
+Assert.Equal("List: 1, 2, 3", res);
 ```
 
 You can also have static arguments in your template that will be parsed into your helper. There are some caveats to this which i'll note below the example:

--- a/src/Stubble.Helpers/HelperExtensions.cs
+++ b/src/Stubble.Helpers/HelperExtensions.cs
@@ -21,7 +21,7 @@ namespace Stubble.Helpers
             }
 
             builder.ConfigureParserPipeline(pipelineBuilder => pipelineBuilder
-                .AddBefore<InterpolationTagParser>(new HelperTagParser()));
+                .AddBefore<InterpolationTagParser>(new HelperTagParser(helpers.HelperMap)));
 
             builder.TokenRenderers.Add(new HelperTagRenderer(helpers.HelperMap));
 

--- a/test/Stubble.Helpers.Test/HelperTests.cs
+++ b/test/Stubble.Helpers.Test/HelperTests.cs
@@ -233,5 +233,20 @@ namespace Stubble.Helpers.Test
 
             Assert.Equal($"<Count#10>", res);
         }
+
+        [Fact]
+        public void ItShouldAllowRegisteredHelpersWithoutArguments()
+        {
+            var helpers = new Helpers()
+                .Register("PrintListWithComma", (context) => string.Join(", ", context.Lookup<int[]>("List")));
+
+            var builder = new StubbleBuilder()
+                .Configure(conf => conf.AddHelpers(helpers))
+                .Build();
+
+            var res = builder.Render("List: {{PrintListWithComma}}", new { List = new[] { 1, 2, 3 } });
+
+            Assert.Equal("List: 1, 2, 3", res);
+        }
     }
 }


### PR DESCRIPTION
We've made it so that we will only consider something a helper if the
name has been registered in the helpers object. This allow us to be
smarter about what we accept and if there should be arguments or not.

Win!

Fixes #18