### PR TITLE
Expose Culture and allow all return types

### DIFF
--- a/src/Stubble.Helpers/HelperContext.cs
+++ b/src/Stubble.Helpers/HelperContext.cs
@@ -11,18 +11,21 @@ namespace Stubble.Helpers
 
         public HelperContext(Context context)
         {
+            if (context is null) throw new ArgumentNullException(nameof(context));
+
             _context = context;
+            RendererSettings = new HelperRendererSettings(_context.RendererSettings);
         }
 
         /// <summary>
         /// Gets the render settings for the context
         /// </summary>
-        public RenderSettings RenderSettings { get;}
+        public RenderSettings RenderSettings => _context.RenderSettings;
 
         /// <summary>
-        /// Gets the registry for the context
+        /// Gets the renderer settings for the context
         /// </summary>
-        public RendererSettings RendererSettings { get; }
+        public HelperRendererSettings RendererSettings { get; }
 
         /// <summary>
         /// Looks up a value by name from the context

--- a/src/Stubble.Helpers/HelperRendererSettings.cs
+++ b/src/Stubble.Helpers/HelperRendererSettings.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Stubble.Core.Settings;
+
+namespace Stubble.Helpers
+{
+    public class HelperRendererSettings
+    {
+        private readonly RendererSettings _rendererSettings;
+
+        public HelperRendererSettings(RendererSettings rendererSettings)
+        {
+            _rendererSettings = rendererSettings;
+        }
+
+        public Func<string, string> EncodingFuction => _rendererSettings.EncodingFuction;
+    }
+}

--- a/src/Stubble.Helpers/HelperTagRenderer.cs
+++ b/src/Stubble.Helpers/HelperTagRenderer.cs
@@ -65,6 +65,10 @@ namespace Stubble.Helpers
                     {
                         renderer.Write(str);
                     }
+                    else if (result is object)
+                    {
+                        renderer.Write(Convert.ToString(result, context.RenderSettings.CultureInfo));
+                    }
                 }
             }
         }

--- a/src/Stubble.Helpers/Helpers.cs
+++ b/src/Stubble.Helpers/Helpers.cs
@@ -11,21 +11,21 @@ namespace Stubble.Helpers
 
         public ImmutableDictionary<string, HelperRef> HelperMap => _helpers.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase);
 
-        public Helpers Register(string name, Func<HelperContext, string> func) => Register(name, (Delegate)func);
-        public Helpers Register<T2>(string name, Func<HelperContext, T2, string> func) => Register(name, (Delegate)func);
-        public Helpers Register<T2, T3>(string name, Func<HelperContext, T2, T3, string> func) => Register(name, (Delegate)func);
-        public Helpers Register<T2, T3, T4>(string name, Func<HelperContext, T2, T3, T4, string> func) => Register(name, (Delegate)func);
-        public Helpers Register<T2, T3, T4, T5>(string name, Func<HelperContext, T2, T3, T4, T5, string> func) => Register(name, (Delegate)func);
-        public Helpers Register<T2, T3, T4, T5, T6>(string name, Func<HelperContext, T2, T3, T4, T5, T6, string> func) => Register(name, (Delegate)func);
-        public Helpers Register<T2, T3, T4, T5, T6, T7>(string name, Func<HelperContext, T2, T3, T4, T5, T6, T7, string> func) => Register(name, (Delegate)func);
-        public Helpers Register<T2, T3, T4, T5, T6, T7, T8>(string name, Func<HelperContext, T2, T3, T4, T5, T6, T7, T8, string> func) => Register(name, (Delegate)func);
-        public Helpers Register<T2, T3, T4, T5, T6, T7, T8, T9>(string name, Func<HelperContext, T2, T3, T4, T5, T6, T7, T8, T9, string> func) => Register(name, (Delegate)func);
-        public Helpers Register<T2, T3, T4, T5, T6, T7, T8, T9, T10>(string name, Func<HelperContext, T2, T3, T4, T5, T6, T7, T8, T9, T10, string> func) => Register(name, (Delegate)func);
-        public Helpers Register<T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(string name, Func<HelperContext, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, string> func) => Register(name, (Delegate)func);
-        public Helpers Register<T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(string name, Func<HelperContext, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, string> func) => Register(name, (Delegate)func);
-        public Helpers Register<T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(string name, Func<HelperContext, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, string> func) => Register(name, (Delegate)func);
-        public Helpers Register<T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(string name, Func<HelperContext, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, string> func) => Register(name, (Delegate)func);
-        public Helpers Register<T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(string name, Func<HelperContext, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, string> func) => Register(name, (Delegate)func);
+        public Helpers Register(string name, Func<HelperContext, object> func) => Register(name, (Delegate)func);
+        public Helpers Register<T2>(string name, Func<HelperContext, T2, object> func) => Register(name, (Delegate)func);
+        public Helpers Register<T2, T3>(string name, Func<HelperContext, T2, T3, object> func) => Register(name, (Delegate)func);
+        public Helpers Register<T2, T3, T4>(string name, Func<HelperContext, T2, T3, T4, object> func) => Register(name, (Delegate)func);
+        public Helpers Register<T2, T3, T4, T5>(string name, Func<HelperContext, T2, T3, T4, T5, object> func) => Register(name, (Delegate)func);
+        public Helpers Register<T2, T3, T4, T5, T6>(string name, Func<HelperContext, T2, T3, T4, T5, T6, object> func) => Register(name, (Delegate)func);
+        public Helpers Register<T2, T3, T4, T5, T6, T7>(string name, Func<HelperContext, T2, T3, T4, T5, T6, T7, object> func) => Register(name, (Delegate)func);
+        public Helpers Register<T2, T3, T4, T5, T6, T7, T8>(string name, Func<HelperContext, T2, T3, T4, T5, T6, T7, T8, object> func) => Register(name, (Delegate)func);
+        public Helpers Register<T2, T3, T4, T5, T6, T7, T8, T9>(string name, Func<HelperContext, T2, T3, T4, T5, T6, T7, T8, T9, object> func) => Register(name, (Delegate)func);
+        public Helpers Register<T2, T3, T4, T5, T6, T7, T8, T9, T10>(string name, Func<HelperContext, T2, T3, T4, T5, T6, T7, T8, T9, T10, object> func) => Register(name, (Delegate)func);
+        public Helpers Register<T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(string name, Func<HelperContext, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, object> func) => Register(name, (Delegate)func);
+        public Helpers Register<T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(string name, Func<HelperContext, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, object> func) => Register(name, (Delegate)func);
+        public Helpers Register<T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(string name, Func<HelperContext, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, object> func) => Register(name, (Delegate)func);
+        public Helpers Register<T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(string name, Func<HelperContext, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, object> func) => Register(name, (Delegate)func);
+        public Helpers Register<T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(string name, Func<HelperContext, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, object> func) => Register(name, (Delegate)func);
 
         private Helpers Register(string name, Delegate @delegate)
         {

--- a/src/Stubble.Helpers/Stubble.Helpers.csproj
+++ b/src/Stubble.Helpers/Stubble.Helpers.csproj
@@ -12,13 +12,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Stubble.Core" Version="1.4.12" />
+    <PackageReference Include="Stubble.Core" Version="1.5.4" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.167" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.28" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/test/Stubble.Helpers.Test/HelperTests.cs
+++ b/test/Stubble.Helpers.Test/HelperTests.cs
@@ -35,6 +35,32 @@ namespace Stubble.Helpers.Test
         }
 
         [Fact]
+        public void HelpersShouldBeAbleToUseRendererContext()
+        {
+            var helpers = new Helpers()
+                .Register<decimal>("FormatCurrency", (context, count) =>
+                {
+                    return count.ToString("C", context.RenderSettings.CultureInfo);
+                });
+
+            var builder = new StubbleBuilder()
+                .Configure(conf =>
+                {
+                    conf.AddHelpers(helpers);
+                })
+                .Build();
+
+            var tmpl = @"{{FormatCurrency Count}}, {{FormatCurrency Count2}}";
+
+            var res = builder.Render(tmpl, new { Count = 10m, Count2 = 100.26m }, new Core.Settings.RenderSettings
+            {
+                CultureInfo = new CultureInfo("en-GB")
+            });
+
+            Assert.Equal("£10.00, £100.26", res);
+        }
+
+        [Fact]
         [UseCulture("en-GB")]
         public void StubbleShouldContinueWorkingAsNormal()
         {

--- a/test/Stubble.Helpers.Test/Stubble.Helpers.Test.csproj
+++ b/test/Stubble.Helpers.Test/Stubble.Helpers.Test.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Stubble.Core" Version="1.4.12" />
+    <PackageReference Include="Stubble.Core" Version="1.5.4" />
     <PackageReference Include="McMaster.Extensions.Xunit" Version="0.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">


### PR DESCRIPTION
Exposes the new Stubble Culture setting to the helper context (correctly as this was broken).

Helpers can now return any type and when converting to string it will use the context culture